### PR TITLE
Remove unused variables in "reference_in_mail_2" function

### DIFF
--- a/2.0/woocommerce-easypay_cc_2/includes/wc-gateway-easypay-mb.php
+++ b/2.0/woocommerce-easypay_cc_2/includes/wc-gateway-easypay-mb.php
@@ -122,7 +122,7 @@ class WC_Gateway_Easypay_MB extends WC_Payment_Gateway
      * @param   $order
      * @param   $sent_to_admin
      */
-    public function reference_in_mail_2($order, $sent_to_admin, $plain_text, $email)
+    public function reference_in_mail_2($order, $sent_to_admin)
     {
         if ($order->get_payment_method() == 'easypay_mb_2') {
             global $wpdb;

--- a/2.0/woocommerce-easypay_mb_2/includes/wc-gateway-easypay-mb.php
+++ b/2.0/woocommerce-easypay_mb_2/includes/wc-gateway-easypay-mb.php
@@ -122,7 +122,7 @@ class WC_Gateway_Easypay_MB extends WC_Payment_Gateway
      * @param   $order
      * @param   $sent_to_admin
      */
-    public function reference_in_mail_2($order, $sent_to_admin, $plain_text, $email)
+    public function reference_in_mail_2($order, $sent_to_admin)
     {
         if ($order->get_payment_method() == 'easypay_mb_2') {
             global $wpdb;

--- a/2.0/woocommerce-easypay_mbway_2/includes/wc-gateway-easypay-mb.php
+++ b/2.0/woocommerce-easypay_mbway_2/includes/wc-gateway-easypay-mb.php
@@ -122,7 +122,7 @@ class WC_Gateway_Easypay_MB extends WC_Payment_Gateway
      * @param   $order
      * @param   $sent_to_admin
      */
-    public function reference_in_mail_2($order, $sent_to_admin, $plain_text, $email)
+    public function reference_in_mail_2($order, $sent_to_admin)
     {
         if ($order->get_payment_method() == 'easypay_mb_2') {
             global $wpdb;


### PR DESCRIPTION
Had conflits when calling "woocommerce_email_after_order_table" action with less than 4 parameters.

Fixes incompatibility with WooCommerce Pre-Orders ( https://woocommerce.com/products/woocommerce-pre-orders/ )